### PR TITLE
fix(ci): use app name todoapp for assertRunningApp on sync/framework-1.3.0

### DIFF
--- a/.devcontainer/test/integration.sh
+++ b/.devcontainer/test/integration.sh
@@ -13,4 +13,4 @@ printInfoSection "Running integration Tests for $RepositoryName"
 
 assertRunningPod todoapp todoapp
 
-assertRunningApp 30100
+assertRunningApp todoapp


### PR DESCRIPTION
## Summary
Framework 1.3.0 changed `assertRunningApp` to take an **app name** and probe the ingress host `<app>.<ip>.<MAGIC_DOMAIN>` / `<app>.<hostname>` on port `K3D_LB_HTTP_PORT`. The repo's integration test was still passing the legacy NodePort `30100`, so the probe used the wrong Host header (`30100.135.237.130.176.sslip.io`) and the request didn't match the `todoapp` ingress rule — failing after 8 retries.

## Fix
- `.devcontainer/test/integration.sh`: `assertRunningApp 30100` → `assertRunningApp todoapp` (aligns with framework 1.3.0's `integration.sh` and the ingress created by `deployTodoApp`, which exposes host `todoapp.<ip>.sslip.io`).

## Test plan
- [ ] CI passes `Test Codespace (devcontainer) build and run commands` step.
- [ ] `assertRunningApp todoapp` finds both ingress hosts (IP magic-DNS + hostname).

Automated fix by the Enablement Ops agent.