### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/getting-started.js"
 --8<-- "snippets/grail-requirements.md"
 
 ## 1. Prerequisites before launching the Codespace

--- a/docs/3-codespaces.md
+++ b/docs/3-codespaces.md
@@ -1,4 +1,3 @@
---8<-- "snippets/3-codespaces.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/4-content.md
+++ b/docs/4-content.md
@@ -1,4 +1,3 @@
---8<-- "snippets/4-content.js"
 
 ## The Dynatrace Codespaces Enablement Framework
 For understanding deeply how the framework works, how to run it locally, the different types of instantiations, integration tests, github actions and more, please read the following documentation: 
@@ -51,20 +50,11 @@ This are the available admonitions added with a snippet:
 
 --8<-- "snippets/admonitions.md"
 
-### The relation between the mkdocs.yaml file, the md files and the javascript files (BizEvents) in the snippets folder.
-The menu on the left hand side is defined in `mkdocs.yaml`. The first page needs to be called index.md, You can call it whatever you want, in our case we call it About. The name from the mkdocs.yaml file will be set as title as long as you add in the same .md file a js file.
+### Page tracking with RUM (BizEvents)
 
-Example the ```index.md``` file has at the top a snippet ```--8<-- "snippets/index.js"```
+Page load events are automatically tracked for every page. The framework`s `docs/overrides/main.html` loads the RUM agent from the `extra.rum_snippet` URL in `mkdocs.yaml`, then fires a `page_load` BizEvent using the page title defined in the `nav` section.
 
-!!! warning "Important"
-    This is because we want to monitor the usage and adoption of the Github pages of your training and since we are using agentless rum, we need to add this to each page. in the JS file we add the same name we defined in the Menu Navigation in the mkdocs.yaml file for having consistency. This way we can understand the engagement of each page, the time the users spent in each page so we can improve our trainings.
-
-As a best practice we recommend for each MD file have a JS file with the same name, and this should be reflected in the mkdocs.yaml file. 
-
-Meaning before going live, after you have created all your MD files, make sure that:
-- each page.md file has a snippet/page.js file associated with it
-- the page.js file inside reflects the same name as in the mkdocs.yaml file, so RUM reflects the page the user is reading.
-
+No per-page JavaScript files are needed. Define your page titles accurately in the `nav` of `mkdocs.yaml` — RUM tracking follows automatically.
 ### Headings in MKDocs
 if you start the md file with a snippet, automatically it'll take the name defined in the mkdocs file. You can override it by adding a Heading1 # which is only one #. For example this page is overriding the heading. As you can see there is no number 4 in the Content. All H2, H3 and so forth will be shown on the right pane for enhanced navigation and better user experience.
 

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/cleanup.js"
 
 
 !!! tip "Deleting the codespace from inside the container"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/index.js"
 
 --8<-- "snippets/disclaimer.md"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,4 +1,3 @@
---8<-- "snippets/resources.js"
 
 ### Get your Dynatrace environment
 

--- a/docs/snippets/2-getting-started.js
+++ b/docs/snippets/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"});
-});
-</script>

--- a/docs/snippets/3-codespaces.js
+++ b/docs/snippets/3-codespaces.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Codespaces"});
-});
-</script>

--- a/docs/snippets/4-content.js
+++ b/docs/snippets/4-content.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Content"});
-});
-</script>

--- a/docs/snippets/cleanup.js
+++ b/docs/snippets/cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Cleanup"});
-});
-</script>

--- a/docs/snippets/index.js
+++ b/docs/snippets/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"});
-});
-</script>

--- a/docs/snippets/resources.js
+++ b/docs/snippets/resources.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Resources"});
-});
-</script>

--- a/docs/snippets/whats-next.js
+++ b/docs/snippets/whats-next.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. What's next?"});
-});
-</script>

--- a/docs/whats-next.md
+++ b/docs/whats-next.md
@@ -1,4 +1,3 @@
---8<-- "snippets/whats-next.js"
 
 --8<-- "snippets/feedback.md"
 


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)