### PR TITLE
fix: provision k3d instead of kind (nightly build fix)

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,7 +5,7 @@ source .devcontainer/util/source_framework.sh
 
 setUpTerminal
 
-startKindCluster
+startK3dCluster
 
 installK9s
 


### PR DESCRIPTION
## Problem
Nightly build fails on Orbital. `post-create.sh` provisioned **kind**, which needs 4-level container nesting that Sysbox cannot virtualise — pods stay stuck `ContainerCreating`.

## Fix
Swap `startKindCluster` → `startK3dCluster`. k3d (3 levels) is the Orbital standard and runs green on Codespaces and bare machines too.

## Compatibility
Framework still ships `startKindCluster` for environments that explicitly want kind (bare machines / Codespaces / public repos). This only changes the repo default to the lowest-common-denominator that is green on **all three** targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)